### PR TITLE
fix wrong chord panel src/dst

### DIFF
--- a/src/chord.js
+++ b/src/chord.js
@@ -244,7 +244,7 @@ function prepData(data, src, target, val) {
     const t = row[targetKey].toString();
     const v = row[valKey];
     // aggregate data
-    matrix[index.get(t)][index.get(s)] += v;
+    matrix[index.get(s)][index.get(y)] += v;
   });
   return [matrix, revIdx];
 }


### PR DESCRIPTION
Expected in D3, matrix[i][j] represents the flow from the ith node in the network to the jth node, but here the source and target are reversed.

> https://github.com/d3/d3-chord#api-reference
> The given matrix must be an array of length n, where each element matrix[i] is an array of n numbers, where each matrix[i][j] represents the flow from the ith node in the network to the jth node.


